### PR TITLE
User-Update Verbesserungen und kleine Fixes

### DIFF
--- a/admin/functions/get-opl-data.php
+++ b/admin/functions/get-opl-data.php
@@ -285,6 +285,7 @@ function create_tournament_get_button(array $data, bool $in_write_popup = false)
 					<button class='get-matchups $id_class' data-id='$id_class'><span>Matches im Turnier updaten (Gruppenweise)</span></button>
 					<button class='get-matchups-delete $id_class' data-id='$id_class'><span>Matches im Turnier updaten + entfernen (Gruppenweise)</span></button>
 					<button class='get-results $id_class' data-id='$id_class'><span>Match-Ergebnisse im Turnier updaten + Spiele (pro Match)</span></button>
+					<button class='get-results-unplayed $id_class' data-id='$id_class'><span>ungespielte Match-Ergebnisse im Turnier updaten + Spiele (pro Match)</span></button>
 					<button class='calculate-standings $id_class' data-id='$id_class'><span>Tabelle des Turniers aktualisieren (Berechnung pro Gruppe)</span></button>
 				</div>
 			</dialog>";

--- a/admin/scripts/main.js
+++ b/admin/scripts/main.js
@@ -9,6 +9,7 @@ function set_button_listeners() {
 	$(".get-matchups").on("click", function () {get_matchups_for_tournament(this.getAttribute("data-id"))});
 	$(".get-matchups-delete").on("click", function () {get_matchups_for_tournament(this.getAttribute("data-id"),true)});
 	$(".get-results").on("click", function () {get_results_for_tournament(this.getAttribute("data-id"))});
+	$(".get-results-unplayed").on("click", function () {get_results_for_tournament(this.getAttribute("data-id"),true)});
 	$(".calculate-standings").on("click", function () {calculate_standings_from_matchups(this.getAttribute("data-id"))});
 	$(".open-tournament-data-popup").on("click", function() {$(`dialog.tournament-data-popup.${this.getAttribute("data-id")}`)[0].showModal()});
 	$(".toggle-turnierselect-accordeon").on("click", function () {
@@ -382,18 +383,21 @@ function get_matchups_for_tournament(tournamentID, deletemissing = false) {
 		.catch(e => console.error(e));
 }
 
-function get_results_for_tournament(tournamentID) {
-	let button = $(".get-results");
+function get_results_for_tournament(tournamentID,unplayed_only=false) {
+	let button = unplayed_only ? $(".get-results-unplayed") : $(".get-results");
 	button.addClass("button-updating");
 	button.prop("disabled", true);
 	let loadingbar_width = 0;
 
+	let matchup_headers = {
+		"type": "matchups",
+		"tournamentid": tournamentID,
+	}
+	if (unplayed_only) matchup_headers["unplayedonly"] = "true";
+
 	fetch(`./ajax/get-data.php`, {
 		method: "GET",
-		headers: {
-			"type": "matchups",
-			"tournamentid": tournamentID,
-		}
+		headers: matchup_headers
 	})
 		.then(res => res.json())
 		.then(async matches => {

--- a/ajax/create-page-elements.php
+++ b/ajax/create-page-elements.php
@@ -30,6 +30,47 @@ if ($type == "matchbutton") {
 	$group_ID = $dbcn->execute_query("SELECT OPL_ID_tournament FROM matchups WHERE OPL_ID = ?", [$match_ID])->fetch_column();
 	echo create_matchbutton($dbcn, $match_ID, $matchtype, $tournament_ID,  $team_ID);
 }
+if ($type == "matchbutton-list-group") {
+	$group_ID = $_SERVER["HTTP_GROUPID"] ?? $_REQUEST["group"] ?? NULL;
+	$group  = $dbcn->execute_query("SELECT * FROM tournaments WHERE OPL_ID = ?", [$group_ID])->fetch_assoc();
+	$tournament_ID = $group["OPL_ID_top_parent"];
+
+	if ($group["format"] == "double-elim" || $group["format"] == "single-elim") {
+		$matches = $dbcn->execute_query("
+                                        SELECT *
+                                        FROM matchups
+                                        WHERE OPL_ID_tournament = ?
+                                          AND NOT ((OPL_ID_team1 IS NULL || matchups.OPL_ID_team1 < 0) AND (OPL_ID_team2 IS NULL OR OPL_ID_team2 < 0))
+                                        ORDER BY plannedDate",[$group_ID])->fetch_all(MYSQLI_ASSOC);
+		$matches_grouped = [];
+		foreach ($matches as $match) {
+			if ($match['plannedDate'] == null) continue;
+			$plannedDate = new DateTime($match['plannedDate']);
+			$plannedDay = $plannedDate->format("Y-m-d H");
+			$matches_grouped[$plannedDay][] = $match;
+		}
+	} else {
+		$matches = $dbcn->execute_query("SELECT * FROM matchups WHERE OPL_ID_tournament = ? ORDER BY playday",[$group_ID])->fetch_all(MYSQLI_ASSOC);
+		$matches_grouped = [];
+		foreach ($matches as $match) {
+			$matches_grouped[$match['playday']][] = $match;
+		}
+	}
+
+	echo "<div class='match-content content'>";
+	foreach ($matches_grouped as $roundNum=>$round) {
+		echo "<div class='match-round'>
+                    <h4>Runde $roundNum</h4>
+                    <div class='divider'></div>
+                    <div class='match-wrapper'>";
+		foreach ($round as $match) {
+			echo create_matchbutton($dbcn,$match['OPL_ID'],"groups",$tournament_ID);
+		}
+		echo "</div>";
+		echo "</div>"; // match-round
+	}
+	echo "</div>"; // match-content
+}
 if ($type == "matchbutton-list-team") {
 	$team_ID = $_SERVER["HTTP_TEAMID"] ?? $_REQUEST['team'] ?? NULL;
 	$group_ID = $_SERVER["HTTP_GROUPID"] ?? $_REQUEST['group'] ?? NULL;

--- a/ajax/get-data.php
+++ b/ajax/get-data.php
@@ -242,6 +242,8 @@ if ($type == "matchups") {
 	$tournamentID = $_SERVER["HTTP_TOURNAMENTID"] ?? NULL;
 	$teamID = $_SERVER["HTTP_TEAMID"] ?? NULL;
 	$id_only = isset($_SERVER["HTTP_IDONLY"]);
+	$unplayed_only = isset($_SERVER["HTTP_UNPLAYEDONLY"]);
+	$unplayed_addon = $unplayed_only ? "AND played IS FALSE" : "";
 	$tournament = $dbcn->execute_query("SELECT * FROM tournaments WHERE OPL_ID = ?", [$tournamentID])->fetch_assoc();
 	$groups = [];
 	if ($tournament["eventType"] == "tournament") {
@@ -256,9 +258,9 @@ if ($type == "matchups") {
 	$matchups = [];
 	foreach ($groups as $group) {
 		if ($teamID == NULL) {
-			$matchup_from_group = $dbcn->execute_query("SELECT * FROM matchups WHERE OPL_ID_tournament = ?", [$group["OPL_ID"]])->fetch_all(MYSQLI_ASSOC);
+			$matchup_from_group = $dbcn->execute_query("SELECT * FROM matchups WHERE OPL_ID_tournament = ? {$unplayed_addon}", [$group["OPL_ID"]])->fetch_all(MYSQLI_ASSOC);
 		} else {
-			$matchup_from_group = $dbcn->execute_query("SELECT * FROM matchups WHERE OPL_ID_tournament = ? AND (OPL_ID_team1 = ? OR OPL_ID_team2 = ?)", [$group["OPL_ID"],$teamID,$teamID])->fetch_all(MYSQLI_ASSOC);
+			$matchup_from_group = $dbcn->execute_query("SELECT * FROM matchups WHERE OPL_ID_tournament = ? AND (OPL_ID_team1 = ? OR OPL_ID_team2 = ?) {$unplayed_addon}", [$group["OPL_ID"],$teamID,$teamID])->fetch_all(MYSQLI_ASSOC);
 		}
 		if ($id_only) {
 			foreach ($matchup_from_group as $matchup) {

--- a/functions/fe-functions.php
+++ b/functions/fe-functions.php
@@ -868,7 +868,7 @@ function create_game(mysqli $dbcn,$gameID,$curr_team=NULL,$tournamentID=null, $r
 			$roles = ["TOP","JUNGLE","MIDDLE","BOTTOM","UTILITY"];
 			$roles_check = array("TOP"=>0,"JUNGLE"=>1,"MIDDLE"=>2,"BOTTOM"=>3,"UTILITY"=>4);
 			$role = $participants[$player_index]['teamPosition'];
-			if ($role != $roles[$player_index-($team_index*5)]) {
+			if ($role != $roles[$player_index-($team_index*5)] && $role !== "") {
 				$player_2_index = $roles_check[$role] + $team_index*5;
 				$helper = $participants[$player_index];
 				$participants[$player_index] = $participants[$player_2_index];

--- a/pages/wildcard-details.php
+++ b/pages/wildcard-details.php
@@ -64,6 +64,7 @@ $matches = $dbcn->execute_query("
                                         ORDER BY plannedDate",[$wildcard['OPL_ID']])->fetch_all(MYSQLI_ASSOC);
 $matches_grouped = [];
 foreach ($matches as $match) {
+    if ($match['plannedDate'] == null) continue;
     $plannedDate = new DateTime($match['plannedDate']);
     $plannedDay = $plannedDate->format("Y-m-d H");
 	$matches_grouped[$plannedDay][] = $match;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1618,6 +1618,7 @@ async function user_update_group(button) {
 			type: "matchups",
 			tournamentID: group_ID,
 			idonly: "true",
+			unplayedonly: "true",
 		}
 	})
 		.then(res => res.json())
@@ -1878,6 +1879,7 @@ async function user_update_team(button) {
 				tournamentID: groupID1,
 				teamid: team_ID,
 				idonly: "true",
+				unplayedonly: "true",
 			}
 		})
 			.then(res => res.json())

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2097,9 +2097,10 @@ async function user_update_match(button) {
 		.then(() => $("div.updatebuttonwrapper span").html("letztes Update:<br>vor ein paar Sekunden"))
 		.catch(e => console.error(e));
 
-	loading_width = 1;
+	loading_width = 20;
 	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
 
+	let games = [];
 	// get matchresult
 	await fetch(`ajax/user-update-functions.php`, {
 		method: "GET",
@@ -2108,158 +2109,12 @@ async function user_update_match(button) {
 			matchID: match_ID,
 		}
 	})
-		.catch(e => console.error(e));
-
-	loading_width = 20;
-	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-
-	let tournamentID;
-	/*
-	// get tournamentID
-	await fetch(`ajax/get-data.php`, {
-		method: "GET",
-		headers: {
-			type: "matchup",
-			matchid: match_ID,
-			returntournamentid: "true",
-		}
-	})
-		.then(res => res.text())
-		.then(id => tournamentID = id)
-		.catch(e => console.error(e));
-	*/
-	/*
-	// get games for players in match
-	await fetch(`ajax/get-data.php`, {
-		method: "GET",
-		headers: {
-			type: "players-in-match",
-			matchid: match_ID,
-			cut_players: "true",
-			idonly: "true",
-		}
-	})
 		.then(res => res.json())
-		.then(async playerids => {
-			for (const playerid of playerids) {
-				await fetch(`admin/ajax/get-rgapi-data.php`, {
-					method: "GET",
-					headers: {
-						type: "games-by-player",
-						playerID: playerid,
-						tournamentID: tournamentID,
-					}
-				})
-					.then(() => {
-						loading_width = loading_width + 30/playerids.length;
-						button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-					})
-					.catch(e => console.error(e));
-				await new Promise(r => setTimeout(r, 100));
+		.then(result => {
+			for (const gameID in result["games"]) {
+				games.push(gameID);
 			}
 		})
-		.catch(e => console.error(e));
-
-	loading_width = 50;
-	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-	*/
-	/*
-	// assign games from players in match
-	await fetch(`ajax/get-data.php`, {
-		method: "GET",
-		headers: {
-			type: "games-from-players-in-match",
-			matchid: match_ID,
-			withPUUIDonly: "true",
-		}
-	})
-		.then(res => res.json())
-		.then(async gameids => {
-			for (const gameid of gameids) {
-				await fetch(`admin/ajax/get-rgapi-data.php`, {
-					method: "GET",
-					headers: {
-						type: "matchdata-and-assign",
-						matchID: gameid,
-						tournamentID: tournamentID,
-					}
-				})
-					.then(() => {
-						loading_width = loading_width + 35/gameids.length;
-						button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-					})
-					.catch(e => console.error(e));
-				await new Promise(r => setTimeout(r, 100));
-			}
-		})
-		.catch(e => console.error(e));
-
-	loading_width = 90;
-	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-	*/
-
-	let games = [];
-	let team1 = [];
-	let team2 = [];
-	// get tournament-id / games / teams
-	await fetch(`ajax/get-data.php`, {
-		method: "GET",
-		headers: {
-			type: "match-games-teams-by-matchid",
-			matchid: match_ID,
-		}
-	})
-		.then(res => res.json())
-		.then(data => {
-			games = data["games"];
-			team1 = data["team1"];
-			team2 = data["team2"];
-			tournamentID = data["match"]["OPL_ID_tournament"];
-		})
-		.catch(e => console.error(e));
-
-	loading_width = 25;
-	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-
-	// gamedata holen
-	for (const game of games) {
-		await fetch(`admin/ajax/get-rgapi-data`, {
-			method: "GET",
-			headers: {
-				type: "add-match-data",
-				matchID: game["RIOT_matchID"],
-				tournamentID: tournamentID,
-			}
-		})
-			.then(() => {
-				loading_width = loading_width + 65/games.length;
-				button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-			})
-			.catch(e => console.error(e));
-	}
-
-	// recalc teamstats
-	await fetch(`ajax/user-update-functions.php`, {
-		method: "GET",
-		headers: {
-			type: "recalc_team_stats",
-			teamID: team1["OPL_ID"],
-			tournamentID: tournamentID,
-		}
-	})
-		.catch(e => console.error(e));
-
-	loading_width = 90;
-	button.style.setProperty("--update-loading-bar-width", `${loading_width}%`);
-
-	await fetch(`ajax/user-update-functions.php`, {
-		method: "GET",
-		headers: {
-			type: "recalc_team_stats",
-			teamID: team2["OPL_ID"],
-			tournamentID: tournamentID,
-		}
-	})
 		.catch(e => console.error(e));
 
 	loading_width = 100;
@@ -2279,11 +2134,10 @@ async function user_update_match(button) {
 		$(".game").remove();
 	}
 	let game_counter = 0;
-	for (const [i, game] of games.entries()) {
+	for (const [i, gameID] of games.entries()) {
 		if (current_match_in_popup === parseInt(match_ID)) {
 			popup.append(`<div class='game game${i}'></div>`);
 		}
-		let gameID = game['RIOT_matchID'];
 
 		let fetchheaders = new Headers({
 			gameid: gameID

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2312,12 +2312,13 @@ async function user_update_match(button) {
 		})
 			.then(res => res.text())
 			.then(data => {
-				let game_wrap = popup.find('.game' + i);
+				let game_wrap = popup.find(`.game${i}`);
 				if (current_match_in_popup === parseInt(match_ID)) {
 					game_wrap.empty();
 					game_wrap.append(data);
 					game_counter++;
 				}
+				popup.find(`.game${i} button.expand-game-details`).on("click", expand_collapse_game);
 			})
 			.catch(e => console.error(e));
 	}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -751,7 +751,7 @@ function switch_elo_view(tournamentID,view) {
         url.searchParams.set("stage","wildcard");
         window.history.replaceState({}, '', url);
         add_elo_team_list(area,tournamentID,"div","wildcard");
-        color_b.text("Nach Liga einfärben");
+        color_b.text("Nach Rang einfärben");
     }
 }
 


### PR DESCRIPTION
User-Update für Gruppen und Teams ist kürzer weil nur noch bisher nicht gespielte Spiele aktualisiert werden
User-Update für Gruppen und Teams lädt jetzt beim Aktualisieren von Spielen direkt die Spieldaten von Riot mit
User-Update für Gruppen und Teams fügt neu hinzugefügte Spiele auch auf die Seite hinzu ohne dass neu geladen werden muss
Im Admin-Dashboard können jetzt alle ungespielten Spiele auf einmal aktualisiert
Weitere kleine Fixes