### PR TITLE
Standings Anpassungen + Kennzeichnung von laufenden Turnieren

### DIFF
--- a/admin/ajax/create_admin_buttons.php
+++ b/admin/ajax/create_admin_buttons.php
@@ -4,5 +4,6 @@ include_once dirname(__FILE__)."/../functions/fe-functions.php";
 $dbcn = create_dbcn();
 
 $open_accordeons = $_SERVER["HTTP_OPEN_ACCORDEONS"] ?? "[]";
+if ($open_accordeons == "") $open_accordeons = "[]";
 $open_accordeons = json_decode($open_accordeons);
 echo create_tournament_buttons($dbcn, $open_accordeons);

--- a/admin/functions/get-opl-data.php
+++ b/admin/functions/get-opl-data.php
@@ -880,8 +880,12 @@ function get_matchups_for_tournament($tournamentID, bool $deletemissing = false)
 				}
 			}
 			$written = true;
-			$dbcn->execute_query("INSERT INTO matchups (OPL_ID, OPL_ID_tournament, OPL_ID_team1, OPL_ID_team2, plannedDate, playday, bestOf, played)
+			try {
+				$dbcn->execute_query("INSERT INTO matchups (OPL_ID, OPL_ID_tournament, OPL_ID_team1, OPL_ID_team2, plannedDate, playday, bestOf, played)
 										VALUES (?, ?, ?, ?, ?, ?, ?, false)", [$match_data["OPL_ID"], $match_data["OPL_ID_tournament"], $match_data["OPL_ID_team1"], $match_data["OPL_ID_team2"], $match_data["plannedDate"], $match_data["playday"], $match_data["bestOf"]]);
+			} catch (Exception $e) {
+				continue;
+			}
 		} else {
 			foreach ($match_data as $key=>$item) {
 				if ($key == "plannedDate" && $matchDB[$key] != null && $item != null) {

--- a/admin/functions/get-opl-data.php
+++ b/admin/functions/get-opl-data.php
@@ -1066,40 +1066,30 @@ function calculate_standings_from_matchups($tournamentID):array {
 			$enemy_id = ($team["OPL_ID"] == $match["OPL_ID_team1"]) ? $match["OPL_ID_team2"] : $match["OPL_ID_team1"];
 			if (!array_key_exists($enemy_id,$standing["wins_vs"])) $standing["wins_vs"][$enemy_id] = 0;
 			if ($match["played"]) {
+				$currentTeamScore = ($team["OPL_ID"] == $match["OPL_ID_team1"]) ? $match["team1Score"] : $match["team2Score"];
+				$enemyTeamScore = ($team["OPL_ID"] == $match["OPL_ID_team2"]) ? $match["team1Score"] : $match["team2Score"];
+
 				$standing["played"]++;
 				if ($match["winner"] == $team["OPL_ID"]) {
 					$standing["wins"]++;
 					$standing["wins_vs"][$enemy_id] += ($enemy_id == $match["OPL_ID_team1"]) ? intval($match["team2Score"]) : intval($match["team1Score"]);
+					$pointsToAdd = match ($match["bestOf"]) {
+						1 => 1,
+						default => 2,
+					};
+					if (is_numeric($currentTeamScore) || $currentTeamScore == "W") {
+						$standing["points"] += $pointsToAdd;
+					}
+				}
+				if (is_numeric($currentTeamScore)) {
+					$standing["single_wins"] += $currentTeamScore;
 				}
 				if ($match["draw"]) {
 					$standing["draws"]++;
+					$standing["points"] += 1;
 				}
 				if ($match["loser"] == $team["OPL_ID"]) {
 					$standing["losses"]++;
-				}
-				// calculate points
-				$currentTeamScore = ($team["OPL_ID"] == $match["OPL_ID_team1"]) ? $match["team1Score"] : $match["team2Score"];
-				$enemyTeamScore = ($team["OPL_ID"] == $match["OPL_ID_team2"]) ? $match["team1Score"] : $match["team2Score"];
-				if (is_numeric($currentTeamScore)) {
-					// Spiel hat ein Ergebnis eingetragen
-					$standing["points"] += $currentTeamScore;
-					$standing["single_wins"] += $currentTeamScore;
-				} else {
-					// Spiel hat nur "W"/"L" eingetragen (zB Def-Win)
-					switch ($match["bestOf"]) {
-						case 1:
-							$pointsToAdd = 1;
-							break;
-						case 2:
-						case 3:
-						default:
-							$pointsToAdd = 2;
-							break;
-						case 5:
-							$pointsToAdd = 3;
-							break;
-					}
-					$standing["points"] += ($currentTeamScore == "W") ? $pointsToAdd : 0;
 				}
 				if (is_numeric($enemyTeamScore)) {
 					$standing["single_losses"] += $enemyTeamScore;

--- a/admin/scripts/main.js
+++ b/admin/scripts/main.js
@@ -31,7 +31,7 @@ function create_tournament_buttons() {
 	if (ref_button != null) {
 		ref_button.innerHTML = "Refreshing...";
 	}
-	const open_accordeons = sessionStorage.getItem("open_admin_accordeons");
+	const open_accordeons = sessionStorage.getItem("open_admin_accordeons") ?? "[]";
 	fetch(`./admin/ajax/create_admin_buttons.php`, {
 		method: "GET",
 		headers: {

--- a/functions/fe-functions.php
+++ b/functions/fe-functions.php
@@ -564,7 +564,7 @@ function create_standings(mysqli $dbcn, $tournament_id, $group_id, $team_id=NULL
 																	AND ttr2.second_ranked_split = true
 														WHERE tit.OPL_ID_group = ?
 															AND teams.OPL_ID > -1
-														ORDER BY IF((standing=0 OR standing IS NULL), 1, 0), standing",[$tournament_id,$tournament_id,$group_id])->fetch_all(MYSQLI_ASSOC);
+														ORDER BY IF((standing=0 OR standing IS NULL), 1, 0), standing, single_wins DESC, single_losses, name",[$tournament_id,$tournament_id,$group_id])->fetch_all(MYSQLI_ASSOC);
 	$tournament = $dbcn->execute_query("SELECT * FROM tournaments WHERE OPL_ID = ?", [$tournament_id])->fetch_assoc();
 
 	$ranked_split_1 = "{$tournament['ranked_season']}-{$tournament['ranked_split']}";

--- a/styles/design2.css
+++ b/styles/design2.css
@@ -2464,6 +2464,26 @@ body.general-team div.pagetitle.team {
 	transition: height 400ms ease-out;
 	position: relative;
 	overflow: hidden;
+
+	&.running-tournament {
+		--pulse-color: color-mix(in srgb, var(--accent), transparent 20%);
+		box-shadow: 0 0 0 2px var(--pulse-color);
+		animation: pulse 2s infinite ease;
+	}
+}
+@keyframes pulse {
+	0% {
+		-moz-box-shadow: 0 0 0 0 var(--pulse-color);
+		box-shadow: 0 0 0 0 var(--pulse-color);
+	}
+	98% {
+		-moz-box-shadow: 0 0 2px 10px transparent;
+		box-shadow: 0 0 2px 10px transparent;
+	}
+	100% {
+		-moz-box-shadow: 0 0 0 0 transparent;
+		box-shadow: 0 0 0 0 transparent;
+	}
 }
 .team-card-div {
 	display: flex;
@@ -2588,6 +2608,12 @@ body.player div.main-content {
 	transition: height 400ms ease-out;
 	position: relative;
 	overflow: hidden;
+
+	&.running-tournament {
+		--pulse-color: color-mix(in srgb, var(--accent), transparent 20%);
+		box-shadow: 0 0 0 2px var(--pulse-color);
+		animation: pulse 2s infinite ease;
+	}
 }
 .player-card.expanded-pcard {
 	height: 362px;

--- a/styles/design2.css
+++ b/styles/design2.css
@@ -2482,7 +2482,7 @@ body.general-team div.pagetitle.team {
 	overflow: hidden;
 
 	&.running-tournament {
-		--pulse-color: color-mix(in srgb, var(--accent), transparent 20%);
+		--pulse-color: var(--accent);
 		box-shadow: 0 0 0 2px var(--pulse-color);
 		animation: pulse 2s infinite ease;
 	}
@@ -2626,7 +2626,7 @@ body.player div.main-content {
 	overflow: hidden;
 
 	&.running-tournament {
-		--pulse-color: color-mix(in srgb, var(--accent), transparent 20%);
+		--pulse-color: var(--accent);
 		box-shadow: 0 0 0 2px var(--pulse-color);
 		animation: pulse 2s infinite ease;
 	}

--- a/styles/design2.css
+++ b/styles/design2.css
@@ -1446,6 +1446,16 @@ div.standings {
 	align-items: center;
 	justify-content: center;
 }
+.standings-table.with-single-games {
+	& .standing-item-wrapper,
+	& .standing-item-wrapper-header {
+		grid-template-columns: calc(100% - 48px - 72px - 56px - 48px) 48px 72px 56px 48px;
+	}
+	& .standing-item-wrapper .score-games {
+		color: var(--text-sec);
+		font-size: 1.05em;
+	}
+}
 .standing-pre.rank {
 	font-size: 1.25em;
 	width: 100%;
@@ -1536,6 +1546,12 @@ div.standings {
 	.standing-item-wrapper,
 	.standing-item-wrapper-header {
 		grid-template-columns: calc(100% - 36px - 72px - 36px) 36px 72px 36px;
+	}
+	.standings-table.with-single-games {
+		& .standing-item-wrapper,
+		& .standing-item-wrapper-header {
+			grid-template-columns: calc(100% - 36px - 48px - 40px - 36px) 36px 48px 40px 36px;
+		}
 	}
 	.standing-item.team {
 		justify-content: start;


### PR DESCRIPTION
- Die Punkteberechnung für Standings wurde den Uniliga-Regeln entsprechend angepasst
- Bei Bo3s/Bo5s werden in den Standings keine Unentschieden angezeigt, dafür die gesamten Siege/Niederlagen in einzelnen Spielen
- Auf der allgemeinen Seite von Teams und Spielern haben laufende Turniere eine animierte Markierung  