### PR TITLE
ID+Slug-URLs hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ FROM php:8.3-apache
 RUN apt-get update
 
 # Install PHP extensions
-RUN docker-php-ext-install pdo pdo_mysql mysqli \
-    && docker-php-ext-enable pdo_mysql mysqli
+RUN apt-get install -y libicu-dev \
+    && docker-php-ext-install pdo pdo_mysql mysqli intl \
+    && docker-php-ext-enable pdo_mysql mysqli intl
 
 RUN apt-get install -y \
         libpng-dev \

--- a/config/routes.php
+++ b/config/routes.php
@@ -9,6 +9,7 @@ $routes = [
 	'turnier/{tournament}/gruppe/{event}' => BASE_PATH.'/public/pages/group-details.php',
 	'turnier/{tournament}/wildcard/{event}' => BASE_PATH.'/public/pages/group-details.php',
 	'turnier/{tournament}/playoffs/{event}' => BASE_PATH.'/public/pages/group-details.php',
+	'turnier/{tournament}/phase/{event}' => BASE_PATH.'/public/pages/group-details.php',
 	'turnier/{tournament}/team/{team}' => BASE_PATH.'/public/pages/teams-tournament-details.php',
 	'turnier/{tournament}/team/{team}/matchhistory' => BASE_PATH.'/public/pages/teams-tournament-matchhistory.php',
 	'turnier/{tournament}/team/{team}/stats' => BASE_PATH.'/public/pages/teams-tournament-statistics.php',

--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -177,10 +177,10 @@ function header_search() {
                 let ac_class = (i===0) ? `class="autocomplete-active"` : "";
                 if (search_results[i]["type"] === "team") {
                     icon = `<span class='material-symbol'>${get_material_icon("groups",true)}</span>`;
-                    link = `/team/${search_results[i]["id"]}`;
+                    link = `/team/${search_results[i]["slug"]}`;
                 } else if (search_results[i]["type"] === "player") {
                     icon = `<span class='material-symbol'>${get_material_icon("person",true)}</span>`;
-                    link = `/spieler/${search_results[i]["id"]}`;
+                    link = `/spieler/${search_results[i]["slug"]}`;
                     additional = (search_results[i]["riotIdName"] !== null) ? `<br>(${search_results[i]["riotIdName"]}#${search_results[i]["riotIdTag"]})` : "";
                 }
                 ac.append($(`<a href="${link}" ${ac_class}>${icon}${search_results[i]["name"]}${additional}</a>`));

--- a/public/pages/elo-overview.php
+++ b/public/pages/elo-overview.php
@@ -19,7 +19,11 @@ $leagues = array_values(array_filter($leagues, function($league) {return !$leagu
 $wildcards = $tournamentRepo->findAllByRootTournamentAndType($tournament, EventType::WILDCARD);
 $wildcards = array_values(array_filter($wildcards, function($wildcard) {return !$wildcard->deactivated;}));
 
-$pageMeta = new PageMeta("Elo-Übersicht - {$tournament->getShortName()}", bodyClass: 'elo-overview');
+$pageMeta = new PageMeta(
+        "Elo-Übersicht - {$tournament->getShortName()}",
+        bodyClass: 'elo-overview',
+        canonicalPath: $tournament->getHref()."/elo"
+);
 AssetManager::addCssAsset('elo-rank-colors.css');
 
 $colored = isset($_GET['colored']);

--- a/public/pages/error.php
+++ b/public/pages/error.php
@@ -16,18 +16,10 @@ switch($errortype) {
 				$errortext = "Kein Turnier unter der angegebenen ID gefunden!";
 				$title = "404 - Turnier nicht gefunden";
 				break;
-			case "group":
-				$errortext = "Keine Gruppe unter der angegebenen ID gefunden!";
-				$title = "404 - Gruppe nicht gefunden";
-				break;
-			case "wildcard":
-				$errortext = "Kein Wildcard-Turnier unter der angegebenen ID gefunden!";
-				$title = "404 - Wildcard-Turnier nicht gefunden";
-				break;
-			case "playoffs":
-				$errortext = "Keine Playoffs unter der angegebenen ID gefunden!";
-				$title = "404 - Playoffs nicht gefunden";
-				break;
+            case "event":
+                $errortext = "Keine Turnierphase unter der angegebenen ID gefunden!";
+                $title = "404 - Event nicht gefunden";
+                break;
 			case "team":
 				$errortext = "Kein Team unter der angegebenen ID gefunden!";
 				$title = "404 - Team nicht gefunden";

--- a/public/pages/group-details.php
+++ b/public/pages/group-details.php
@@ -18,7 +18,8 @@ $group = $tournamentRepo->findStandingsEventById($_GET["event"]);
 $pageMeta = new PageMeta(
         title: $group->getFullName()." | ".$group->rootTournament->getShortName(),
         bodyClass: 'group',
-        bodyDataId: $group->id
+        bodyDataId: $group->id,
+        canonicalPath: $group->rootTournament->getHref()."/phase/".$group->getSlug()
 );
 
 ?>

--- a/public/pages/player-details.php
+++ b/public/pages/player-details.php
@@ -10,7 +10,11 @@ $playerRepo = new PlayerRepository();
 
 $player = $playerRepo->findById($_GET["player"]);
 
-$pageMeta = new PageMeta($player->name, bodyClass: 'player');
+$pageMeta = new PageMeta(
+        $player->name,
+        bodyClass: 'player',
+        canonicalPath: 'spieler/'.$player->getSlug()
+);
 
 ?>
 

--- a/public/pages/startpage.php
+++ b/public/pages/startpage.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Domain\Entities\Tournament;
 use App\Domain\Repositories\TournamentRepository;
 use App\Domain\Services\EntitySorter;
 use App\UI\Components\Navigation\Header;
@@ -12,6 +13,7 @@ $pageMeta = new PageMeta(bodyClass: 'home');
 $tournamentRepo = new TournamentRepository();
 $tournaments = $tournamentRepo->findAllRootTournaments();
 $tournaments = EntitySorter::sortTournamentsByStartDate($tournaments);
+/** @var Tournament[] $tournaments */
 $tournaments = array_values(array_filter($tournaments, function($tournament) {return !$tournament->deactivated;}));
 
 echo new Header(HeaderType::HOME);
@@ -23,7 +25,7 @@ echo new Header(HeaderType::HOME);
 		    <h2>Turniere</h2>
             <?php foreach ($tournaments as $i=>$tournament):?>
 				<?= ($i != 0) ? '<div class="divider"></div>' : '' ?>
-                <a href="/turnier/<?= $tournament->id ?>" class="turnier-button <?= $tournament->id ?>">
+                <a href="<?= $tournament->getHref() ?>" class="turnier-button <?= $tournament->id ?>">
                     <?php if($tournament->getLogoUrl()): ?>
                         <img class='color-switch' alt src='<?= $tournament->getLogoUrl() ?>'>
                     <?php else: ?>

--- a/public/pages/team-details.php
+++ b/public/pages/team-details.php
@@ -21,7 +21,11 @@ $team = $teamRepo->findById($_GET["team"]);
 $teamInTournaments = $teamInTournamentRepo->findAllByTeam($team);
 $teamInTournaments = EntitySorter::sortTeamInTournamentsByStartDate($teamInTournaments);
 
-$pageMeta = new PageMeta($team->name, bodyClass: 'team general-team');
+$pageMeta = new PageMeta(
+        $team->name,
+        bodyClass: 'team general-team',
+        canonicalPath: 'team/'.$team->getSlug()
+);
 
 ?>
 

--- a/public/pages/teams-list.php
+++ b/public/pages/teams-list.php
@@ -20,7 +20,11 @@ $teamInTournamentStageRepo = new TeamInTournamentStageRepository();
 
 $tournament = $tournamentRepo->findById($_GET['tournament']);
 
-$pageMeta = new PageMeta("Team-Liste - {$tournament->getShortName()}", bodyClass: 'teamlist');
+$pageMeta = new PageMeta(
+        "Team-Liste - {$tournament->getShortName()}",
+        bodyClass: 'teamlist',
+        canonicalPath: $tournament->getHref()."/teams"
+);
 AssetManager::addJsModule('components/teamsList');
 
 echo new Header(HeaderType::TOURNAMENT, $tournament);

--- a/public/pages/teams-tournament-details.php
+++ b/public/pages/teams-tournament-details.php
@@ -45,7 +45,8 @@ foreach ($teamInTournamentStages as $teamInTournamentStageInLoop) {
 
 $pageMeta = new PageMeta(
 	title: $teamInTournament->nameInTournament." | ".$teamInTournament->tournament->getShortName(),
-	bodyClass: 'team'
+	bodyClass: 'team',
+    canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()
 );
 
 ?>

--- a/public/pages/teams-tournament-matchhistory.php
+++ b/public/pages/teams-tournament-matchhistory.php
@@ -37,7 +37,8 @@ foreach ($teamInTournamentStages as $teamInTournamentStageInLoop) {
 
 $pageMeta = new PageMeta(
         title: "$teamInTournament->nameInTournament - Matchhistory | {$teamInTournament->tournament->getShortName()}",
-        bodyClass: 'match-history'
+        bodyClass: 'match-history',
+        canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()."/matchhistory"
 );
 
 ?>

--- a/public/pages/teams-tournament-statistics.php
+++ b/public/pages/teams-tournament-statistics.php
@@ -34,7 +34,8 @@ $teamInTournamentStage = end($teamInTournamentStages);
 
 $pageMeta = new PageMeta(
 	title: "$teamInTournament->nameInTournament - Statistiken | ".$teamInTournament->tournament->getShortName(),
-	bodyClass: 'statistics'
+	bodyClass: 'statistics',
+	canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()."/stats"
 );
 AssetManager::addJsModule('components/statistics');
 

--- a/public/pages/tournament-details.php
+++ b/public/pages/tournament-details.php
@@ -64,9 +64,9 @@ $playoffs_active = (count($wildcards)==0 && count($leagues)==0 && count($playoff
                             <div class='group'>
                                 <span class="group-title">Gruppe</span>
                                 <div class="divider-vert-acc"></div>
-                                <?= new PageLink("/turnier/{$tournament->id}/gruppe/{$league->id}",'Details')?>
+                                <?= new PageLink($league->getHref(),'Details')?>
                                 <div class="divider-vert-acc"></div>
-                                <?= new PageLink("/turnier/{$tournament->id}/teams?liga={$league->id}", 'Teams', materialIcon: 'group')?>
+                                <?= new PageLink($tournament->getHref()."/teams?liga={$league->id}", 'Teams', materialIcon: 'group')?>
                             </div>
                         </div>
                     </div>
@@ -91,9 +91,9 @@ $playoffs_active = (count($wildcards)==0 && count($leagues)==0 && count($playoff
                             <div class="group">
                                 <span class="group-title"><?= $group->getShortName() ?></span>
                                 <div class="divider-vert-acc"></div>
-                                <?= new PageLink("/turnier/{$tournament->id}/gruppe/{$group->id}",'Details') ?>
+                                <?= new PageLink($group->getHref(),'Details') ?>
                                 <div class="divider-vert-acc"></div>
-                                <?= new PageLink("/turnier/{$tournament->id}/teams?liga={$league->id}&gruppe={$group->id}", 'Teams', materialIcon: 'group') ?>
+                                <?= new PageLink($tournament->getHref()."/teams?liga={$league->id}&gruppe={$group->id}", 'Teams', materialIcon: 'group') ?>
                             </div>
                         <?php endforeach; ?>
                     </div>
@@ -114,9 +114,9 @@ $playoffs_active = (count($wildcards)==0 && count($leagues)==0 && count($playoff
                         <div class="group">
                             <span class="group-title"><?= $wildcard->getShortName() ?></span>
                             <div class="divider-vert-acc"></div>
-							<?= new PageLink("/turnier/{$tournament->id}/wildcard/{$wildcard->id}",'Details') ?>
+							<?= new PageLink($wildcard->getHref(),'Details') ?>
                             <div class="divider-vert-acc"></div>
-							<?= new PageLink("/turnier/{$tournament->id}/teams?liga={$wildcard->id}", 'Teams', materialIcon: 'group') ?>
+							<?= new PageLink($tournament->getHref()."/teams?liga={$wildcard->id}", 'Teams', materialIcon: 'group') ?>
                         </div>
                     <?php endforeach; ?>
                 </div>
@@ -136,9 +136,9 @@ $playoffs_active = (count($wildcards)==0 && count($leagues)==0 && count($playoff
                         <div class="group">
                             <span class="group-title"><?= $playoff->getShortName() ?></span>
                             <div class="divider-vert-acc"></div>
-							<?= new PageLink("/turnier/{$tournament->id}/playoffs/{$playoff->id}",'Details') ?>
+							<?= new PageLink($playoff->getHref(),'Details') ?>
                             <div class="divider-vert-acc"></div>
-							<?= new PageLink("/turnier/{$tournament->id}/teams?liga={$playoff->id}", 'Teams', materialIcon: 'group') ?>
+							<?= new PageLink($tournament->getHref()."/teams?liga={$playoff->id}", 'Teams', materialIcon: 'group') ?>
                         </div>
                     <?php endforeach; ?>
                 </div>

--- a/public/pages/tournament-details.php
+++ b/public/pages/tournament-details.php
@@ -14,7 +14,11 @@ $tournamentRepo = new TournamentRepository();
 
 $tournament = $tournamentRepo->findById($_GET['tournament']);
 
-$pageMeta = new PageMeta($tournament->getShortName(),bodyClass: 'tournament');
+$pageMeta = new PageMeta(
+        $tournament->getShortName(),
+        bodyClass: 'tournament',
+        canonicalPath: $tournament->getHref()
+);
 AssetManager::addJsModule('components/switchTournamentEvents');
 
 ?>

--- a/src/API/SearchHandler.php
+++ b/src/API/SearchHandler.php
@@ -32,10 +32,23 @@ class SearchHandler {
 		$searchResults = [];
 		foreach ($resultEntities as $entity) {
 			if ($entity instanceof Player) {
-				$searchResults[] = ["type"=>"player","id"=>$entity->id,"name"=>$entity->name,"riotIdName"=>$entity->riotIdName,"riotIdTag"=>$entity->riotIdTag];
+				$searchResults[] = [
+					"type"=>"player",
+					"id"=>$entity->id,
+					"slug"=>$entity->getSlug(),
+					"name"=>$entity->name,
+					"riotIdName"=>$entity->riotIdName,
+					"riotIdTag"=>$entity->riotIdTag
+				];
 			}
 			if ($entity instanceof Team) {
-				$searchResults[] = ["type"=>"team","id"=>$entity->id,"name"=>$entity->name,"shortName"=>$entity->shortName];
+				$searchResults[] = [
+					"type"=>"team",
+					"id"=>$entity->id,
+					"slug"=>$entity->getSlug(),
+					"name"=>$entity->name,
+					"shortName"=>$entity->shortName
+				];
 			}
 		}
 

--- a/src/Core/Router.php
+++ b/src/Core/Router.php
@@ -196,9 +196,7 @@ class Router {
 		$playerRepo = new PlayerRepository();
 
 		self::validateIntId($params, 'tournament', fn($id)=>$tournamentRepo->tournamentExists($id, EventType::TOURNAMENT));
-		self::validateIntId($params, 'group', fn($id)=>$tournamentRepo->standingEventExists($id));
-		self::validateIntId($params, 'wildcard', fn($id)=>$tournamentRepo->tournamentExists($id, EventType::WILDCARD));
-		self::validateIntId($params, 'playoffs', fn($id)=>$tournamentRepo->tournamentExists($id, EventType::PLAYOFFS));
+		self::validateIntId($params, 'event', fn($id)=>$tournamentRepo->standingEventExists($id));
 		self::validateIntId($params, 'team', fn($id)=>$teamRepo->teamExists($id));
 		self::validateIntId($params, 'player', fn($id)=>$playerRepo->playerExists($id));
 
@@ -208,6 +206,8 @@ class Router {
 		if (!isset($params[$param])) {
 			return;
 		}
+
+		$params[$param] = explode('-', $params[$param])[0];
 		$params[$param] = filter_var($params[$param], FILTER_VALIDATE_INT);
 
 		if (!$params[$param] || !$existsCallback($params[$param])) {

--- a/src/Domain/Entities/Matchup.php
+++ b/src/Domain/Entities/Matchup.php
@@ -85,6 +85,6 @@ class Matchup {
 	}
 
 	public function getLink(): string {
-		return "/turnier/".$this->tournamentStage->getRootTournament()->id."/".$this->tournamentStage->getUrlKey()."/".$this->tournamentStage->id."?match=".$this->id;
+		return $this->tournamentStage->getHref()."?match=".$this->id;
 	}
 }

--- a/src/Domain/Entities/Player.php
+++ b/src/Domain/Entities/Player.php
@@ -36,4 +36,11 @@ class Player {
 		$this->riotIdName = $riotId[0];
 		$this->riotIdTag = $riotId[1] ?? null;
 	}
+
+	public function getSlug(): string {
+		$name = transliterator_transliterate('Any-Latin; Latin-ASCII;', $this->name);
+		$name = preg_replace('/[^a-z0-9]+/i', '-', $name);
+		$name = trim($name, '-');
+		return $this->id."-".strtolower($name);
+	}
 }

--- a/src/Domain/Entities/Team.php
+++ b/src/Domain/Entities/Team.php
@@ -34,6 +34,13 @@ class Team {
 		return $this->rank->rankTier !== null;
 	}
 
+	public function getSlug(): string {
+		$name = transliterator_transliterate('Any-Latin; Latin-ASCII;', $this->name);
+		$name = preg_replace('/[^a-z0-9]+/i', '-', $name);
+		$name = trim($name, '-');
+		return $this->id."-".strtolower($name);
+	}
+
 	public function getDataDifference(Team $team): array {
 		$diffToOther = [];
 		if ($this->id !== $team->id) $diffToOther['id'] = $this->id;

--- a/src/Domain/Entities/Tournament.php
+++ b/src/Domain/Entities/Tournament.php
@@ -88,25 +88,26 @@ class Tournament {
 		return (is_null($this->dateEnd) || $this->dateEnd > $today);
 	}
 
-	public function getUrlKey():string {
-		return match ($this->eventType) {
-			EventType::TOURNAMENT => "turnier",
-			EventType::LEAGUE => "liga",
-			EventType::GROUP => "gruppe",
-			EventType::WILDCARD => "wildcard",
-			EventType::PLAYOFFS => "playoffs",
-			default => "",
-		};
-	}
 	public function getHref(): string {
 		if ($this->eventType == EventType::TOURNAMENT) {
-			return "/turnier/".$this->id;
+			return "/turnier/".$this->getSlug();
 		}
-		$urlKey = $this->getUrlKey();
-		if ($this->eventType === EventType::LEAGUE && $this->format === EventFormat::SWISS) {
-			$urlKey = 'gruppe';
-		}
-		return "/turnier/{$this->rootTournament->id}/$urlKey/{$this->id}";
+		return "/turnier/{$this->rootTournament->getSlug()}/phase/{$this->getSlug()}";
+	}
+
+	public function getSlug():string {
+		$id = $this->id;
+		$name = match ($this->eventType) {
+			EventType::TOURNAMENT => $this->split."-".$this->season,
+			EventType::LEAGUE, EventType::PLAYOFFS, EventType::WILDCARD => $this->getShortName(),
+			EventType::GROUP => $this->directParentTournament->getShortName()."-".$this->getShortName(),
+			default => "",
+		};
+
+		$namePart = transliterator_transliterate("Any-Latin; Latin-ASCII", $name);
+		$namePart = preg_replace("/[^a-z0-9]+/i", "-", $namePart);
+		$namePart = trim($namePart, "-");
+		return $id."-".strtolower($namePart);
 	}
 
 	public function getNumberFormatted():string {
@@ -134,10 +135,9 @@ class Tournament {
 		}
 		return match ($this->eventType) {
 			EventType::TOURNAMENT => preg_replace("/LoL\s/i","",$this->name),
-			EventType::LEAGUE => $this->getFullName(),
+			EventType::LEAGUE, EventType::PLAYOFFS => $this->getFullName(),
 			EventType::GROUP => "Gruppe ".$this->getNumberFormatted(),
 			EventType::WILDCARD => "Wildcard Liga ".$this->getNumberFormatted(),
-			EventType::PLAYOFFS => $this->getFullName(),
 			default => "",
 		};
 	}

--- a/src/UI/Components/Cards/team-in-tournament-card.template.php
+++ b/src/UI/Components/Cards/team-in-tournament-card.template.php
@@ -28,7 +28,7 @@ $classes = implode(' ', array_filter(['team-card', $teamInTournamentStage->tourn
     )?>
 
     <?= new PageLinkWrapper(
-            href: $teamInTournamentStage->tournamentStage->rootTournament->getHref()."/team/".$teamInTournamentStage->team->id,
+            href: $teamInTournamentStage->tournamentStage->rootTournament->getHref()."/team/".$teamInTournamentStage->team->getSlug(),
             additionalClasses: ['team-card-div','team-card-teampage'],
             content: $teamImg.PageLinkWrapper::makeTarget($teamInTournamentStage->teamInRootTournament->nameInTournament,true)
     )?>

--- a/src/UI/Components/Cards/team-in-tournament-card.template.php
+++ b/src/UI/Components/Cards/team-in-tournament-card.template.php
@@ -16,7 +16,7 @@ $classes = implode(' ', array_filter(['team-card', $teamInTournamentStage->tourn
 
 <div class="<?=$classes?>">
     <?= new PageLinkWrapper(
-            href: "/turnier/{$teamInTournamentStage->tournamentStage->rootTournament->id}",
+            href: $teamInTournamentStage->tournamentStage->rootTournament->getHref(),
             additionalClasses: ['team-card-div','team-card-tournament'],
             content: $tournamentImg.PageLinkWrapper::makeTarget($teamInTournamentStage->tournamentStage->rootTournament->getSplitAndSeason(), withoutIcon: true)
     )?>

--- a/src/UI/Components/Cards/team-in-tournament-card.template.php
+++ b/src/UI/Components/Cards/team-in-tournament-card.template.php
@@ -68,7 +68,7 @@ $classes = implode(' ', array_filter(['team-card', $teamInTournamentStage->tourn
                 }
                 ?>
                 <?= new PageLinkWrapper(
-                        href: "/spieler/{$playerInTeamInTournament->player->id}",
+                        href: "/spieler/{$playerInTeamInTournament->player->getSlug()}",
                         content: $roleHtml.PageLinkWrapper::makeTarget($playerInTeamInTournament->player->name, true)
                 )?>
             <?php endforeach; ?>

--- a/src/UI/Components/EliminationBrackets/double-elimination-bracket.template.php
+++ b/src/UI/Components/EliminationBrackets/double-elimination-bracket.template.php
@@ -18,8 +18,7 @@ use App\UI\Components\UI\PageLink;
             Standings
             <?php
             if ($this->selectedTeam !== null) {
-                $groupLinkUrl = "/turnier/".$this->tournamentStage->rootTournament->id."/".$this->tournamentStage->getUrlKey()."/".$this->tournamentStage->id;
-                echo new PageLink($groupLinkUrl, $this->tournamentStage->getFullName());
+                echo new PageLink($this->tournamentStage->getHref(), $this->tournamentStage->getFullName());
             }
             ?>
         </h3>

--- a/src/UI/Components/EliminationBrackets/single-elimination-bracket.template.php
+++ b/src/UI/Components/EliminationBrackets/single-elimination-bracket.template.php
@@ -16,8 +16,7 @@ use App\UI\Components\UI\PageLink;
             Standings
             <?php
             if ($this->selectedTeam !== null) {
-                $groupLinkUrl = "/turnier/" . $this->tournamentStage->rootTournament->id . "/" . $this->tournamentStage->getUrlKey() . "/" . $this->tournamentStage->id;
-                echo new PageLink($groupLinkUrl, $this->tournamentStage->getFullName());
+                echo new PageLink($this->tournamentStage->getHref(), $this->tournamentStage->getFullName());
             }
             ?>
         </h3>

--- a/src/UI/Components/Games/game-details.template.php
+++ b/src/UI/Components/Games/game-details.template.php
@@ -53,7 +53,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($blueTeamExists): ?>
         <?php $classes = implode(' ', array_filter(['team', $blueTeamScoreClass, $currentTeamIsBlueClass])) ?>
-        <a class="<?=$classes?>" href="/turnier/<?= $gameInMatch->matchup->tournamentStage->rootTournament->id ?>/team/<?= $gameInMatch->blueTeam->team->id ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->blueTeam->team->id ?>">
 			<?php if ($gameInMatch->blueTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->blueTeam->getLogoUrl(true) ?>">
 			<?php endif; ?>
@@ -84,7 +84,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($redTeamExists): ?>
 		<?php $classes = implode(' ', array_filter(['team', $redTeamScoreClass, $currentTeamIsRedClass])) ?>
-        <a class="<?=$classes?>" href="/turnier/<?= $gameInMatch->matchup->tournamentStage->rootTournament->id ?>/team/<?= $gameInMatch->redTeam->team->id ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->redTeam->team->id ?>">
             <?php if ($gameInMatch->redTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->redTeam->getLogoUrl(true) ?>">
             <?php endif; ?>
@@ -106,7 +106,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 			foreach ([$gameInMatch->blueTeam, $gameInMatch->redTeam] as $index=> $team): ?>
                 <?php if (!is_null($team)): ?>
 				<?php $classes = implode(' ', array_filter(['team', $index+1, $teamScoreClasses[$index], $currentTeamClasses[$index]])) ?>
-                <a class="<?=$classes?>" href="/turnier/<?= $gameInMatch->matchup->tournamentStage->rootTournament->id ?>/team/<?= $team->team->id ?>">
+                <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $team->team->id ?>">
                     <div class="name">
 						<?php if ($team->getLogoUrl(true)): ?>
                             <img class="color-switch" alt="" src="<?= $team->getLogoUrl(true) ?>">

--- a/src/UI/Components/Games/game-details.template.php
+++ b/src/UI/Components/Games/game-details.template.php
@@ -53,7 +53,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($blueTeamExists): ?>
         <?php $classes = implode(' ', array_filter(['team', $blueTeamScoreClass, $currentTeamIsBlueClass])) ?>
-        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->blueTeam->team->id ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->blueTeam->team->getSlug() ?>">
 			<?php if ($gameInMatch->blueTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->blueTeam->getLogoUrl(true) ?>">
 			<?php endif; ?>
@@ -84,7 +84,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($redTeamExists): ?>
 		<?php $classes = implode(' ', array_filter(['team', $redTeamScoreClass, $currentTeamIsRedClass])) ?>
-        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->redTeam->team->id ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->redTeam->team->getSlug() ?>">
             <?php if ($gameInMatch->redTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->redTeam->getLogoUrl(true) ?>">
             <?php endif; ?>
@@ -106,7 +106,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 			foreach ([$gameInMatch->blueTeam, $gameInMatch->redTeam] as $index=> $team): ?>
                 <?php if (!is_null($team)): ?>
 				<?php $classes = implode(' ', array_filter(['team', $index+1, $teamScoreClasses[$index], $currentTeamClasses[$index]])) ?>
-                <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $team->team->id ?>">
+                <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $team->team->getSlug() ?>">
                     <div class="name">
 						<?php if ($team->getLogoUrl(true)): ?>
                             <img class="color-switch" alt="" src="<?= $team->getLogoUrl(true) ?>">

--- a/src/UI/Components/Matches/match-round.template.php
+++ b/src/UI/Components/Matches/match-round.template.php
@@ -12,7 +12,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
     	<span class="round">Runde <?=$matchup->playday?>: &nbsp;</span>
     <?php endif; ?>
     <?= new PageLink(
-            href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team1?->team->id}",
+            href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team1?->team->getSlug()}",
             text: $team1Name,
             additionalClasses: ["team", $matchup->getTeam1Result()],
             linkIcon: false
@@ -25,7 +25,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
         <span class="score">vs.</span>
     <?php endif; ?>
 	<?= new PageLink(
-		href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team2?->team->id}",
+		href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team2?->team->getSlug()}",
 		text: $team2Name,
 		additionalClasses: ["team", $matchup->getTeam2Result()],
 		linkIcon: false

--- a/src/UI/Components/Matches/match-round.template.php
+++ b/src/UI/Components/Matches/match-round.template.php
@@ -12,7 +12,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
     	<span class="round">Runde <?=$matchup->playday?>: &nbsp;</span>
     <?php endif; ?>
     <?= new PageLink(
-            href: "/turnier/{$matchup->tournamentStage->rootTournament->id}/team/{$matchup->team1?->team->id}",
+            href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team1?->team->id}",
             text: $team1Name,
             additionalClasses: ["team", $matchup->getTeam1Result()],
             linkIcon: false
@@ -25,7 +25,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
         <span class="score">vs.</span>
     <?php endif; ?>
 	<?= new PageLink(
-		href: "/turnier/{$matchup->tournamentStage->rootTournament->id}/team/{$matchup->team2?->team->id}",
+		href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team2?->team->id}",
 		text: $team2Name,
 		additionalClasses: ["team", $matchup->getTeam2Result()],
 		linkIcon: false

--- a/src/UI/Components/Navigation/team-header-nav.template.php
+++ b/src/UI/Components/Navigation/team-header-nav.template.php
@@ -20,7 +20,7 @@ use App\UI\Components\UpdateButton;
     ?>
 	<div>
 		<h2 class='pagetitle'>
-            <?= new PageLink("/team/{$teamInTournament->team->id}",$teamInTournament->nameInTournament)?>
+            <?= new PageLink("/team/{$teamInTournament->team->getSlug()}",$teamInTournament->nameInTournament)?>
 		</h2>
         <?= new OplOutLink($teamInTournament->team)?>
 	</div>
@@ -31,15 +31,15 @@ use App\UI\Components\UpdateButton;
 ?>
 </div>
 <nav class='team-titlebutton-wrapper'>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('info')?>
 		Team-Übersicht
 	</a>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('manage_search')?>
 		Match-History
 	</a>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('monitoring')?>
 		Statistiken
 	</a>

--- a/src/UI/Components/Navigation/team-header-nav.template.php
+++ b/src/UI/Components/Navigation/team-header-nav.template.php
@@ -31,15 +31,15 @@ use App\UI\Components\UpdateButton;
 ?>
 </div>
 <nav class='team-titlebutton-wrapper'>
-	<a href='/turnier/<?=$teamInTournament->tournament->id?>/team/<?=$teamInTournament->team->id?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('info')?>
 		Team-Übersicht
 	</a>
-	<a href='/turnier/<?=$teamInTournament->tournament->id?>/team/<?=$teamInTournament->team->id?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('manage_search')?>
 		Match-History
 	</a>
-	<a href='/turnier/<?=$teamInTournament->tournament->id?>/team/<?=$teamInTournament->team->id?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->id?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('monitoring')?>
 		Statistiken
 	</a>

--- a/src/UI/Components/Navigation/tournament-nav.template.php
+++ b/src/UI/Components/Navigation/tournament-nav.template.php
@@ -9,17 +9,17 @@ use App\UI\Components\Helpers\IconRenderer;
 <nav class='turnier-bonus-buttons'>
 	<div class='turnier-nav-buttons'>
         <?php $classes = implode(' ', array_filter(['button', ($activeTab === 'overview')?'active':'']))?>
-		<a href='/turnier/<?= $tournament->id?>' class='<?=$classes?>'>
+		<a href='<?= $tournament->getHref()?>' class='<?=$classes?>'>
             <?= IconRenderer::getMaterialIconDiv('sports_esports')?>
 			Turnier
 		</a>
 		<?php $classes = implode(' ', array_filter(['button', ($activeTab === 'teamlist')?'active':'']))?>
-		<a href='/turnier/<?= $tournament->id?>/teams' class='<?=$classes?>'>
+		<a href='<?= $tournament->getHref()?>/teams' class='<?=$classes?>'>
 			<?= IconRenderer::getMaterialIconDiv('group')?>
 			Teams
 		</a>
 		<?php $classes = implode(' ', array_filter(['button', ($activeTab === 'elo')?'active':'']))?>
-		<a href='/turnier/<?= $tournament->id?>/elo' class='<?=$classes?>'>
+		<a href='<?= $tournament->getHref()?>/elo' class='<?=$classes?>'>
 			<?= IconRenderer::getMaterialIconDiv('stars')?>
 			Eloverteilung
 		</a>

--- a/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
+++ b/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
@@ -30,7 +30,7 @@ $classes = implode(' ', array_filter(['player-card', $tournament->isRunning() ? 
 	)?>
 
 	<?= new PageLinkWrapper(
-		href: $tournament->getHref()."/team/".$team->id,
+		href: $tournament->getHref()."/team/".$team->getSlug(),
 		additionalClasses: ['player-card-div', 'player-card-team'],
 		content: $teamImg.PageLinkWrapper::makeTarget($playerInTeamInTournament->teamInTournament->nameInTournament,true)
     )?>

--- a/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
+++ b/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
@@ -24,7 +24,7 @@ $classes = implode(' ', array_filter(['player-card', $tournament->isRunning() ? 
 
 <div class="<?=$classes?>" data-details="<?=$detailAmount?>">
 	<?= new PageLinkWrapper(
-		href: "/turnier/{$tournament->id}",
+		href: $tournament->getHref(),
 		additionalClasses: ['player-card-div','player-card-tournament'],
 		content: $tournamentImg.PageLinkWrapper::makeTarget($tournament->getSplitAndSeason(), withoutIcon: true)
 	)?>

--- a/src/UI/Components/Player/player-overview.template.php
+++ b/src/UI/Components/Player/player-overview.template.php
@@ -12,7 +12,7 @@ use App\UI\Components\UI\PageLink;
 
 <?php if ($showPlayerPageLink): ?>
 <?= new PageLink(
-	href: "/spieler/{$player->id}",
+	href: "/spieler/{$player->getSlug()}",
 	text: 'Zur Spielerseite',
 	materialIcon: 'person'
 )?>

--- a/src/UI/Components/Popups/team-popup-content.template.php
+++ b/src/UI/Components/Popups/team-popup-content.template.php
@@ -27,7 +27,7 @@ use App\UI\Components\UI\SummonerCardCollapseButton;
 </div>
 
 <?= new PageLink(
-        href: "/turnier/{$teamInTournament->tournament->id}/team/{$teamInTournament->team->id}",
+        href: "{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->team->id}",
         text: "Team-Übersicht"
 )?>
 

--- a/src/UI/Components/Popups/team-popup-content.template.php
+++ b/src/UI/Components/Popups/team-popup-content.template.php
@@ -17,7 +17,7 @@ use App\UI\Components\UI\SummonerCardCollapseButton;
 	<div>
 		<h2>
 			<?= new PageLink(
-				href: "/team/{$teamInTournament->team->id}",
+				href: "/team/{$teamInTournament->team->getSlug()}",
 				text: $teamInTournament->nameInTournament,
                 linkIcon: ''
 			)?>
@@ -27,7 +27,7 @@ use App\UI\Components\UI\SummonerCardCollapseButton;
 </div>
 
 <?= new PageLink(
-        href: "{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->team->id}",
+        href: "{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->team->getSlug()}",
         text: "Team-Übersicht"
 )?>
 

--- a/src/UI/Components/Standings/TeamLinkInRow.php
+++ b/src/UI/Components/Standings/TeamLinkInRow.php
@@ -15,7 +15,7 @@ class TeamLinkInRow {
 	public function __construct(
 		public TeamInTournamentStage $teamInTournamentStage
 	) {
-		$this->href = "{$teamInTournamentStage->tournamentStage->rootTournament->getHref()}/team/{$teamInTournamentStage->team->id}";
+		$this->href = "{$teamInTournamentStage->tournamentStage->rootTournament->getHref()}/team/{$teamInTournamentStage->team->getSlug()}";
 
 		$this->teamNameTargetHtml = PageLinkWrapper::makeTarget(
 			"<span class='team-name' title='{$teamInTournamentStage->teamInRootTournament->nameInTournament}'>{$teamInTournamentStage->teamInRootTournament->nameInTournament}</span>"

--- a/src/UI/Components/Standings/TeamLinkInRow.php
+++ b/src/UI/Components/Standings/TeamLinkInRow.php
@@ -15,7 +15,7 @@ class TeamLinkInRow {
 	public function __construct(
 		public TeamInTournamentStage $teamInTournamentStage
 	) {
-		$this->href = "/turnier/{$teamInTournamentStage->tournamentStage->rootTournament->id}/team/{$teamInTournamentStage->team->id}";
+		$this->href = "{$teamInTournamentStage->tournamentStage->rootTournament->getHref()}/team/{$teamInTournamentStage->team->id}";
 
 		$this->teamNameTargetHtml = PageLinkWrapper::makeTarget(
 			"<span class='team-name' title='{$teamInTournamentStage->teamInRootTournament->nameInTournament}'>{$teamInTournamentStage->teamInRootTournament->nameInTournament}</span>"

--- a/src/UI/Components/Standings/standings-table.template.php
+++ b/src/UI/Components/Standings/standings-table.template.php
@@ -4,8 +4,7 @@
 			Standings
 			<?php
             if ($this->selectedTeam !== null) {
-                $groupLinkUrl = "/turnier/".$this->tournamentStage->rootTournament->id."/".$this->tournamentStage->getUrlKey()."/".$this->tournamentStage->id;
-                echo new \App\UI\Components\UI\PageLink($groupLinkUrl, $this->tournamentStage->getFullName());
+                echo new \App\UI\Components\UI\PageLink($this->tournamentStage->getHref(), $this->tournamentStage->getFullName());
             }
             ?>
 		</h3>

--- a/src/UI/Page/LayoutRenderer.php
+++ b/src/UI/Page/LayoutRenderer.php
@@ -16,6 +16,9 @@ class LayoutRenderer {
 			<title>
 				<?= $meta->title ?>
 			</title>
+            <?php if ($meta->canonicalPath !== ''): ?>
+                <link rel="canonical" href="<?= $meta->getCanonicalUrl() ?>">
+            <?php endif; ?>
             <?php foreach(AssetManager::getCssFiles() as $css): ?>
                 <link rel="stylesheet" href="<?= $css ?>">
             <?php endforeach; ?>

--- a/src/UI/Page/PageMeta.php
+++ b/src/UI/Page/PageMeta.php
@@ -7,7 +7,8 @@ class PageMeta {
 	public function __construct(
 		public string $title = '',
 		public string $bodyClass = '',
-		public string $bodyDataId = ''
+		public string $bodyDataId = '',
+		public string $canonicalPath = ''
 	) {
 		if ($title) {
 			$this->shortTitle = $title;
@@ -20,5 +21,9 @@ class PageMeta {
 		AssetManager::addJsAsset('jquery-3.7.1.min.js');
 		AssetManager::addJsModuleAsset('main.js');
 		$this->bodyDataId = "data-id='{$this->bodyDataId}'";
+	}
+
+	public function getCanonicalUrl(): string {
+		return 'https://'.$_SERVER['SERVER_NAME'] . '/' . ltrim($this->canonicalPath, '/');
 	}
 }


### PR DESCRIPTION
Urls sind durch Slugs lesbarer geworden, z.B.:
- vorher: turnier/6667/gruppe/6925
- jetzt: turnier/6667-winter-25/phase/6925-liga-1-gruppe-a

Deswegen teilen sich jetzt auch Gruppen, Wildcards und Playoffs das URL-Segment "phase" (für Turnier*phase*), da die Event-Art aus dem Slug hervorgeht.

Da so mehrere URLs auf die gleichen Seiten zeigen können (alte URLs mit nur Ids weiterhin gültig, allgemein wird beim Auswerten nur die Id bis zum Bindestrich gelesen) wurden auch kanonische URLs für alle betroffenen Seiten festgelegt