### PR TITLE
Nutze Team-Namen während Turnieren für URL-Slugs; Fallback Bilder für fehlende Ids

### DIFF
--- a/public/pages/teams-tournament-details.php
+++ b/public/pages/teams-tournament-details.php
@@ -46,7 +46,7 @@ foreach ($teamInTournamentStages as $teamInTournamentStageInLoop) {
 $pageMeta = new PageMeta(
 	title: $teamInTournament->nameInTournament." | ".$teamInTournament->tournament->getShortName(),
 	bodyClass: 'team',
-    canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()
+    canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->getSlug()
 );
 
 ?>

--- a/public/pages/teams-tournament-matchhistory.php
+++ b/public/pages/teams-tournament-matchhistory.php
@@ -38,7 +38,7 @@ foreach ($teamInTournamentStages as $teamInTournamentStageInLoop) {
 $pageMeta = new PageMeta(
         title: "$teamInTournament->nameInTournament - Matchhistory | {$teamInTournament->tournament->getShortName()}",
         bodyClass: 'match-history',
-        canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()."/matchhistory"
+        canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->getSlug()."/matchhistory"
 );
 
 ?>

--- a/public/pages/teams-tournament-statistics.php
+++ b/public/pages/teams-tournament-statistics.php
@@ -35,7 +35,7 @@ $teamInTournamentStage = end($teamInTournamentStages);
 $pageMeta = new PageMeta(
 	title: "$teamInTournament->nameInTournament - Statistiken | ".$teamInTournament->tournament->getShortName(),
 	bodyClass: 'statistics',
-	canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->team->getSlug()."/stats"
+	canonicalPath: $teamInTournament->tournament->getHref()."/team/".$teamInTournament->getSlug()."/stats"
 );
 AssetManager::addJsModule('components/statistics');
 

--- a/src/Core/SitemapHandler.php
+++ b/src/Core/SitemapHandler.php
@@ -39,7 +39,7 @@ class SitemapHandler {
 
 			$teamsInTournament = $teamInTournamentRepo->findAllByRootTournament($tournament);
 			foreach ($teamsInTournament as $teamInTournament) {
-				$this->addUrl("{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->team->getSlug()}");
+				$this->addUrl("{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->getSlug()}");
 			}
 		}
 

--- a/src/Domain/Entities/Patch.php
+++ b/src/Domain/Entities/Patch.php
@@ -49,7 +49,7 @@ class Patch {
 				}
 			}
 		}
-		return null;
+		return "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D";
 	}
 	public function getRuneNameById(int $runeId): ?string {
 		$this->getRuneData();
@@ -79,6 +79,7 @@ class Patch {
     }
 	public function getSummonerSpellUrlById(int $summonerSpellId): ?string {
 		$this->getSummonerSpellData();
+		if (!isset($this->summonerSpellData[$summonerSpellId])) return "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D";
 		return $this->imgUrl.'/spell/'.$this->summonerSpellData[$summonerSpellId].'.webp';
 	}
 
@@ -94,10 +95,13 @@ class Patch {
         return $this->itemData;
     }
 	public function getItemUrlById(int $itemId): ?string {
+		$this->getItemData();
+		if (!isset($this->itemData[$itemId])) return "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D";
 		return $this->imgUrl."/item/$itemId.webp";
 	}
 	public function getItemNameById(int $itemId): ?string {
 		$this->getItemData();
+		if (!isset($this->itemData[$itemId])) return "Item $itemId";
 		return $this->itemData[$itemId]['name'];
 	}
 

--- a/src/Domain/Entities/Patch.php
+++ b/src/Domain/Entities/Patch.php
@@ -114,6 +114,7 @@ class Patch {
     }
 	public function getChampionUrlById(int $championId): ?string {
 		$this->getChampionData();
+		if (!isset($this->championData[$championId])) return "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs%3D";
 		return $this->imgUrl.'/champion/'.$this->championData[$championId].'.webp';
 	}
 }

--- a/src/Domain/Entities/TeamInTournament.php
+++ b/src/Domain/Entities/TeamInTournament.php
@@ -47,4 +47,11 @@ class TeamInTournament {
 			return $baseUrl."logo$squareAddition.webp";
 		}
 	}
+
+	public function getSlug(): string {
+		$name = transliterator_transliterate('Any-Latin; Latin-ASCII;', $this->nameInTournament);
+		$name = preg_replace('/[^a-z0-9]+/i', '-', $name);
+		$name = trim($name, '-');
+		return $this->team->id."-".strtolower($name);
+	}
 }

--- a/src/UI/Components/Cards/team-in-tournament-card.template.php
+++ b/src/UI/Components/Cards/team-in-tournament-card.template.php
@@ -28,7 +28,7 @@ $classes = implode(' ', array_filter(['team-card', $teamInTournamentStage->tourn
     )?>
 
     <?= new PageLinkWrapper(
-            href: $teamInTournamentStage->tournamentStage->rootTournament->getHref()."/team/".$teamInTournamentStage->team->getSlug(),
+            href: $teamInTournamentStage->tournamentStage->rootTournament->getHref()."/team/".$teamInTournamentStage->teamInRootTournament->getSlug(),
             additionalClasses: ['team-card-div','team-card-teampage'],
             content: $teamImg.PageLinkWrapper::makeTarget($teamInTournamentStage->teamInRootTournament->nameInTournament,true)
     )?>

--- a/src/UI/Components/Games/game-details.template.php
+++ b/src/UI/Components/Games/game-details.template.php
@@ -53,7 +53,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($blueTeamExists): ?>
         <?php $classes = implode(' ', array_filter(['team', $blueTeamScoreClass, $currentTeamIsBlueClass])) ?>
-        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->blueTeam->team->getSlug() ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->blueTeam->getSlug() ?>">
 			<?php if ($gameInMatch->blueTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->blueTeam->getLogoUrl(true) ?>">
 			<?php endif; ?>
@@ -84,7 +84,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 
         <?php if ($redTeamExists): ?>
 		<?php $classes = implode(' ', array_filter(['team', $redTeamScoreClass, $currentTeamIsRedClass])) ?>
-        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->redTeam->team->getSlug() ?>">
+        <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $gameInMatch->redTeam->getSlug() ?>">
             <?php if ($gameInMatch->redTeam->getLogoUrl(true)): ?>
                 <img class="color-switch" alt="" src="<?= $gameInMatch->redTeam->getLogoUrl(true) ?>">
             <?php endif; ?>
@@ -106,7 +106,7 @@ if ($teamFocus && $winningTeamExists && $currentTeam->equals($gameInMatch->getWi
 			foreach ([$gameInMatch->blueTeam, $gameInMatch->redTeam] as $index=> $team): ?>
                 <?php if (!is_null($team)): ?>
 				<?php $classes = implode(' ', array_filter(['team', $index+1, $teamScoreClasses[$index], $currentTeamClasses[$index]])) ?>
-                <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $team->team->getSlug() ?>">
+                <a class="<?=$classes?>" href="<?= $gameInMatch->matchup->tournamentStage->rootTournament->getHref() ?>/team/<?= $team->getSlug() ?>">
                     <div class="name">
 						<?php if ($team->getLogoUrl(true)): ?>
                             <img class="color-switch" alt="" src="<?= $team->getLogoUrl(true) ?>">

--- a/src/UI/Components/Matches/match-round.template.php
+++ b/src/UI/Components/Matches/match-round.template.php
@@ -12,7 +12,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
     	<span class="round">Runde <?=$matchup->playday?>: &nbsp;</span>
     <?php endif; ?>
     <?= new PageLink(
-            href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team1?->team->getSlug()}",
+            href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team1?->getSlug()}",
             text: $team1Name,
             additionalClasses: ["team", $matchup->getTeam1Result()],
             linkIcon: false
@@ -25,7 +25,7 @@ $team2Name = (is_null($matchup->team2)) ? "TBD" : $matchup->team2->nameInTournam
         <span class="score">vs.</span>
     <?php endif; ?>
 	<?= new PageLink(
-		href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team2?->team->getSlug()}",
+		href: "{$matchup->tournamentStage->rootTournament->getHref()}/team/{$matchup->team2?->getSlug()}",
 		text: $team2Name,
 		additionalClasses: ["team", $matchup->getTeam2Result()],
 		linkIcon: false

--- a/src/UI/Components/Navigation/team-header-nav.template.php
+++ b/src/UI/Components/Navigation/team-header-nav.template.php
@@ -31,15 +31,15 @@ use App\UI\Components\UpdateButton;
 ?>
 </div>
 <nav class='team-titlebutton-wrapper'>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->getSlug()?>' class='<?= $activeTab === 'details' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('info')?>
 		Team-Übersicht
 	</a>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->getSlug()?>/matchhistory' class='<?= $activeTab === 'matchhistory' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('manage_search')?>
 		Match-History
 	</a>
-	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->team->getSlug()?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
+	<a href='<?=$teamInTournament->tournament->getHref()?>/team/<?=$teamInTournament->getSlug()?>/stats' class='<?= $activeTab === 'stats' ? 'active' : ''?>'>
         <?= IconRenderer::getMaterialIconDiv('monitoring')?>
 		Statistiken
 	</a>

--- a/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
+++ b/src/UI/Components/Player/player-in-tournament-in-team-card.template.php
@@ -30,7 +30,7 @@ $classes = implode(' ', array_filter(['player-card', $tournament->isRunning() ? 
 	)?>
 
 	<?= new PageLinkWrapper(
-		href: $tournament->getHref()."/team/".$team->getSlug(),
+		href: $tournament->getHref()."/team/".$playerInTeamInTournament->teamInTournament->getSlug(),
 		additionalClasses: ['player-card-div', 'player-card-team'],
 		content: $teamImg.PageLinkWrapper::makeTarget($playerInTeamInTournament->teamInTournament->nameInTournament,true)
     )?>

--- a/src/UI/Components/Popups/team-popup-content.template.php
+++ b/src/UI/Components/Popups/team-popup-content.template.php
@@ -27,7 +27,7 @@ use App\UI\Components\UI\SummonerCardCollapseButton;
 </div>
 
 <?= new PageLink(
-        href: "{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->team->getSlug()}",
+        href: "{$teamInTournament->tournament->getHref()}/team/{$teamInTournament->getSlug()}",
         text: "Team-Übersicht"
 )?>
 

--- a/src/UI/Components/Standings/TeamLinkInRow.php
+++ b/src/UI/Components/Standings/TeamLinkInRow.php
@@ -15,7 +15,7 @@ class TeamLinkInRow {
 	public function __construct(
 		public TeamInTournamentStage $teamInTournamentStage
 	) {
-		$this->href = "{$teamInTournamentStage->tournamentStage->rootTournament->getHref()}/team/{$teamInTournamentStage->team->getSlug()}";
+		$this->href = "{$teamInTournamentStage->tournamentStage->rootTournament->getHref()}/team/{$teamInTournamentStage->teamInRootTournament->getSlug()}";
 
 		$this->teamNameTargetHtml = PageLinkWrapper::makeTarget(
 			"<span class='team-name' title='{$teamInTournamentStage->teamInRootTournament->nameInTournament}'>{$teamInTournamentStage->teamInRootTournament->nameInTournament}</span>"


### PR DESCRIPTION
- URL-Slugs von Teams in Turnieren `/turnier/{turnier}/team/{team}` verwenden jetzt den Namen, den das Team zum Zeitpunkt des Turniers hatte, statt den aktuellen
- Fallback Bilder für nicht vorhandene Ids von Champions, Items, Summoner-Spells und Runen hinzugefügt