### PR TITLE
Fixes für Notification-Menü und Links im Header, und Sitemap Formatierung

### DIFF
--- a/src/Core/SitemapHandler.php
+++ b/src/Core/SitemapHandler.php
@@ -16,8 +16,8 @@ class SitemapHandler {
 		$teamRepo = new TeamRepository();
 		$playerRepo = new PlayerRepository();
 
-		echo '<?xml version="1.0" encoding="UTF-8"?>';
-		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+		echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL;
 
 		// Startseite
 		$this->addUrl('/');
@@ -60,8 +60,8 @@ class SitemapHandler {
 	}
 
 	private function addUrl(string $path): void {
-		echo '<url>';
-		echo '<loc>' . htmlspecialchars("https://" . ($_SERVER['SERVER_NAME']) . $path) . '</loc>';
-		echo '</url>';
+		echo '<url>'.PHP_EOL;
+		echo '<loc>' . htmlspecialchars("https://" . ($_SERVER['SERVER_NAME']) . $path, ENT_XML1 | ENT_COMPAT, 'UTF-8') . '</loc>'.PHP_EOL;
+		echo '</url>'.PHP_EOL;
 	}
 }

--- a/src/UI/Components/Navigation/header.template.php
+++ b/src/UI/Components/Navigation/header.template.php
@@ -62,9 +62,9 @@ use App\UI\Components\Popups\Popup;
     	<a class='settings-option' href='https://ko-fi.com/silencelol' target='_blank'>Spenden<?= IconRenderer::getMaterialIconDiv('payments')?></a>
         <a class='settings-option feedback' href=''>Feedback<?= IconRenderer::getMaterialIconDiv('mail')?></a>
         <?php if (UserContext::isLoggedIn()): ?>
-            <a class='settings-option logout' href='?logout'>Logout<?= IconRenderer::getMaterialIconDiv('logout')?></a>
+            <a class='settings-option logout' href='?logout' rel="nofollow">Logout<?= IconRenderer::getMaterialIconDiv('logout')?></a>
         <?php else: ?>
-            <a class='settings-option login' href='?login'>Login<?= IconRenderer::getMaterialIconDiv('login')?></a>
+            <a class='settings-option login' href='?login' rel="nofollow">Login<?= IconRenderer::getMaterialIconDiv('login')?></a>
         <?php endif; ?>
     </div>
 </header>

--- a/src/UI/Components/Navigation/header.template.php
+++ b/src/UI/Components/Navigation/header.template.php
@@ -40,16 +40,16 @@ use App\UI\Components\Popups\Popup;
 
     <?php if (UserContext::isLoggedIn()): ?>
         <button class='notifications-button'><?= count($matchupChangeSuggestions) === 0 ? IconRenderer::getMaterialIconSpan('notifications') : IconRenderer::getMaterialIconSpan('notifications_unread')?></button>
+        <div class="notifications-menu">
+            <div class="notifications-menu-header">
+                <span>Vorgeschlagene Änderungen</span>
+                <button type="button" class="refresh-notifications"><?=IconRenderer::getMaterialIconSpan("refresh")?></button>
+            </div>
+            <div class="notifications-menu-content">
+                <?= new NotificationSuggestionList($matchupChangeSuggestions) ?>
+            </div>
+        </div>
     <?php endif; ?>
-    <div class="notifications-menu">
-        <div class="notifications-menu-header">
-            <span>Vorgeschlagene Änderungen</span>
-            <button type="button" class="refresh-notifications"><?=IconRenderer::getMaterialIconSpan("refresh")?></button>
-        </div>
-        <div class="notifications-menu-content">
-            <?= new NotificationSuggestionList($matchupChangeSuggestions) ?>
-        </div>
-    </div>
 
 	<button type='button' class='material-symbol settings-button'><?= IconRenderer::getMaterialIcon('tune')?></button>
 


### PR DESCRIPTION
- `rel="nofollow"` zu Login und Logout Links im Header hinzugefügt.
- Das Notification Menü für Spieländerungen wird jetzt für nicht eingeloggte Nutzer nicht mehr gerendert (Auch wenn es versteckt war)
- Formatierung der XML-Sitemap wurde durch Linebreaks verbessert